### PR TITLE
Optimized Get-ComObjects

### DIFF
--- a/Public/Get-ComObjects.ps1
+++ b/Public/Get-ComObjects.ps1
@@ -1,0 +1,37 @@
+function Get-ComObjects {
+  [CmdletBinding()]
+  param(
+    [ValidateScript({
+      $_.Count -eq $_.Where{ -not [String]::IsNullOrEmpty($_) }.Count
+    })]
+    [string[]]
+    $Filter
+  )
+
+  $Filter = $Filter.ForEach('ToLower')
+  $rgx = [regex]::new('^\w+\.\w+$', 'Compiled')
+
+  Get-ChildItem Registry::HKEY_CLASSES_ROOT -ea SilentlyContinue -pv k | &{process{
+    if( $rgx.Match($k.PSChildName).Success ){
+      $clsidExists =
+        try {
+          $obj = [Microsoft.Win32.Registry]::ClassesRoot.OpenSubkey($k.PSChildName)
+          ($false,$true)[ 'CLSID' -in $obj.GetSubKeyNames() ]
+        }
+        catch [Management.Automation.RuntimeException] {
+          $false
+        }
+        finally {
+          try{ $obj.Dispose() }catch{}
+        }
+      if( $clsidExists -and $Filter ){
+        if( $Filter.Where{ $k.PSChildName.ToLower().Contains($_) } ){
+          $_.PSChildName
+        }
+      }
+      elseif( $clsidExists ){
+        $_.PSChildName
+      }
+    }
+  }}
+}


### PR DESCRIPTION
I noticed that Get-ComObject(s) was gone from your module. When I tried the latest revision, I could see why. It was very, very slow. So I optimized the hell out of it.

There was a lot of .NET used just for speed's sake, it's just not fast enough otherwise.